### PR TITLE
Prevent overwriting version link

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -41,3 +41,4 @@
     dest: "{{ mediawiki_docroot }}/mediawiki"
     state: link
     mode: "0755"
+  when: mediawiki_destination != mediawiki_docroot


### PR DESCRIPTION
---
name: Pull request
about: Prevent overwriting version link

---

**Describe the change**
Only create the docroot link, if `mediawiki_destination` != `mediawiki_docroot` to prevent overwriting the version link

**Testing**
In a playbook, tests succeeded with

    - role: robertdebock.mediawiki
      mediawiki_destination: /opt
      
and with

    - role: robertdebock.mediawiki
