### PR TITLE
Use variable instead of hardcoded MediaWiki name

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -8,10 +8,13 @@ mediawiki_release: 1
 
 mediawiki_version: "{{ mediawiki_major }}.{{ mediawiki_minor }}.{{ mediawiki_release }}"
 
-# Where to install mediawiki. You can use this pattern to install to a default
+# Where to install MediaWiki. You can use this pattern to install to a default
 # location that differs per distribution, see `vars/main.yml`:
 # "{{ _mediawiki_destination[ansible_distribution] | default(_mediawiki_destination['default']) }}"
 # Change this to a simple string that refers to a path, for example:
 # "/data/mediawiki".
 
 mediawiki_destination: "{{ _mediawiki_destination[ansible_distribution] | default(_mediawiki_destination['default']) }}"
+
+# The wiki's name used in directories and links
+mediawiki_name: "mediawiki"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -16,5 +16,8 @@ mediawiki_version: "{{ mediawiki_major }}.{{ mediawiki_minor }}.{{ mediawiki_rel
 
 mediawiki_destination: "{{ _mediawiki_destination[ansible_distribution] | default(_mediawiki_destination['default']) }}"
 
+# The wiki's name prefix used in directories and links
+mediawiki_name_prefix: "wiki-"
+
 # The wiki's name used in directories and links
 mediawiki_name: "mediawiki"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -21,3 +21,6 @@ mediawiki_name_prefix: "wiki-"
 
 # The wiki's name used in directories and links
 mediawiki_name: "mediawiki"
+
+# Compile install path variable
+mediawiki_install_path: "{{ mediawiki_destination }}/{{ mediawiki_name_prefix }}{{ mediawiki_name }}"

--- a/molecule/default/verify.yml
+++ b/molecule/default/verify.yml
@@ -7,6 +7,6 @@
   tasks:
     - name: connect to mediawiki
       ansible.builtin.get_url:
-        url: https://localhost/mediawiki
+        url: http://localhost/mediawiki
         dest: /tmp/whatever
         validate_certs: no

--- a/tasks/assert.yml
+++ b/tasks/assert.yml
@@ -34,3 +34,10 @@
       - mediawiki_destination is defined
       - mediawiki_destination is string
     quiet: yes
+
+- name: test if mediawiki_name is set correctly
+  ansible.builtin.assert:
+    that:
+      - mediawiki_name is defined
+      - mediawiki_name is string
+    quiet: yes

--- a/tasks/assert.yml
+++ b/tasks/assert.yml
@@ -35,6 +35,13 @@
       - mediawiki_destination is string
     quiet: yes
 
+- name: test if mediawiki_name_prefix is set correctly
+  ansible.builtin.assert:
+    that:
+      - mediawiki_name_prefix is defined
+      - mediawiki_name_prefix is string
+    quiet: yes
+
 - name: test if mediawiki_name is set correctly
   ansible.builtin.assert:
     that:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -48,7 +48,7 @@
 
 - name: link mediawiki to versioned directory
   ansible.builtin.file:
-    src: "{{ mediawiki_destination }}/{{ mediawiki_name }}-{{ mediawiki_version }}"
+    src: "{{ mediawiki_destination }}/{{ mediawiki_name_prefix }}{{ mediawiki_name }}-{{ mediawiki_version }}"
     dest: "{{ mediawiki_destination }}/{{ mediawiki_name_prefix }}{{ mediawiki_name }}"
     state: link
     mode: "0755"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -24,21 +24,21 @@
     src: "{{ mediawiki_source }}"
     dest: "{{ mediawiki_destination }}"
     remote_src: yes
-    creates: "{{ mediawiki_destination }}/mediawiki-{{ mediawiki_version }}"
+    creates: "{{ mediawiki_destination }}/{{ mediawiki_name }}-{{ mediawiki_version }}"
     setype: httpd_sys_script_rw_t
     mode: "0755"
 
 - name: link mediawiki to versioned directory
   ansible.builtin.file:
-    src: "{{ mediawiki_destination }}/mediawiki-{{ mediawiki_version }}"
-    dest: "{{ mediawiki_destination }}/mediawiki"
+    src: "{{ mediawiki_destination }}/{{ mediawiki_name }}-{{ mediawiki_version }}"
+    dest: "{{ mediawiki_destination }}/{{ mediawiki_name }}"
     state: link
     mode: "0755"
 
 - name: link mediawiki to docroot
   ansible.builtin.file:
-    src: "{{ mediawiki_destination }}/mediawiki"
-    dest: "{{ mediawiki_docroot }}/mediawiki"
+    src: "{{ mediawiki_destination }}/{{ mediawiki_name }}"
+    dest: "{{ mediawiki_docroot }}/{{ mediawiki_name }}"
     state: link
     mode: "0755"
   when: mediawiki_destination != mediawiki_docroot

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -32,6 +32,7 @@
   stat:
     path: "{{ mediawiki_destination }}/{{ mediawiki_name }}-{{ mediawiki_version }}"
   register: stat_mediawiki_dir
+  when: mediawiki_name != "mediawiki"
 
 - name: discard existing MediaWiki dir
   file:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -38,7 +38,9 @@
   file:
     path: "{{ mediawiki_destination }}/{{ mediawiki_name }}-{{ mediawiki_version }}"
     state: absent
-  when: stat_mediawiki_dir
+  when:
+    - stat_mediawiki_dir
+    - mediawiki_name != "mediawiki"
 
 - name: rename mediawiki directory
   command: mv "{{ mediawiki_destination }}/mediawiki-{{ mediawiki_version }}" "{{ mediawiki_destination }}/{{ mediawiki_name }}-{{ mediawiki_version }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -30,33 +30,33 @@
 
 - name: is MediaWiki dir present?
   stat:
-    path: "{{ mediawiki_destination }}/{{ mediawiki_name }}-{{ mediawiki_version }}"
+    path: "{{ mediawiki_destination }}/{{ mediawiki_name_prefix }}{{ mediawiki_name }}-{{ mediawiki_version }}"
   register: stat_mediawiki_dir
   when: mediawiki_name != "mediawiki"
 
 - name: discard existing MediaWiki dir
   file:
-    path: "{{ mediawiki_destination }}/{{ mediawiki_name }}-{{ mediawiki_version }}"
+    path: "{{ mediawiki_destination }}/{{ mediawiki_name_prefix }}{{ mediawiki_name }}-{{ mediawiki_version }}"
     state: absent
   when:
     - stat_mediawiki_dir
     - mediawiki_name != "mediawiki"
 
 - name: rename mediawiki directory
-  command: mv "{{ mediawiki_destination }}/mediawiki-{{ mediawiki_version }}" "{{ mediawiki_destination }}/{{ mediawiki_name }}-{{ mediawiki_version }}"
+  command: mv "{{ mediawiki_destination }}/mediawiki-{{ mediawiki_version }}" "{{ mediawiki_destination }}/{{ mediawiki_name_prefix }}{{ mediawiki_name }}-{{ mediawiki_version }}"
   when: mediawiki_name != "mediawiki"
 
 - name: link mediawiki to versioned directory
   ansible.builtin.file:
     src: "{{ mediawiki_destination }}/{{ mediawiki_name }}-{{ mediawiki_version }}"
-    dest: "{{ mediawiki_destination }}/{{ mediawiki_name }}"
+    dest: "{{ mediawiki_destination }}/{{ mediawiki_name_prefix }}{{ mediawiki_name }}"
     state: link
     mode: "0755"
 
 - name: link mediawiki to docroot
   ansible.builtin.file:
     src: "{{ mediawiki_destination }}/{{ mediawiki_name }}"
-    dest: "{{ mediawiki_docroot }}/{{ mediawiki_name }}"
+    dest: "{{ mediawiki_docroot }}/{{ mediawiki_name_prefix }}{{ mediawiki_name }}"
     state: link
     mode: "0755"
   when: mediawiki_destination != mediawiki_docroot

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -30,6 +30,7 @@
 
 - name: rename mediawiki directory
   command: mv "{{ mediawiki_destination }}/mediawiki-{{ mediawiki_version }}" "{{ mediawiki_destination }}/{{ mediawiki_name }}-{{ mediawiki_version }}"
+  when: mediawiki_name != "mediawiki"
 
 - name: link mediawiki to versioned directory
   ansible.builtin.file:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -24,9 +24,12 @@
     src: "{{ mediawiki_source }}"
     dest: "{{ mediawiki_destination }}"
     remote_src: yes
-    creates: "{{ mediawiki_destination }}/{{ mediawiki_name }}-{{ mediawiki_version }}"
+    creates: "{{ mediawiki_destination }}/mediawiki-{{ mediawiki_version }}"
     setype: httpd_sys_script_rw_t
     mode: "0755"
+
+- name: rename mediawiki directory
+  command: mv "{{ mediawiki_destination }}/mediawiki-{{ mediawiki_version }}" "{{ mediawiki_destination }}/{{ mediawiki_name }}-{{ mediawiki_version }}"
 
 - name: link mediawiki to versioned directory
   ansible.builtin.file:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -55,7 +55,7 @@
 
 - name: link mediawiki to docroot
   ansible.builtin.file:
-    src: "{{ mediawiki_destination }}/{{ mediawiki_name }}"
+    src: "{{ mediawiki_destination }}/{{ mediawiki_name_prefix }}{{ mediawiki_name }}"
     dest: "{{ mediawiki_docroot }}/{{ mediawiki_name_prefix }}{{ mediawiki_name }}"
     state: link
     mode: "0755"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -28,6 +28,17 @@
     setype: httpd_sys_script_rw_t
     mode: "0755"
 
+- name: is MediaWiki dir present?
+  stat:
+    path: "{{ mediawiki_destination }}/{{ mediawiki_name }}-{{ mediawiki_version }}"
+  register: stat_mediawiki_dir
+
+- name: discard existing MediaWiki dir
+  file:
+    path: "{{ mediawiki_destination }}/{{ mediawiki_name }}-{{ mediawiki_version }}"
+    state: absent
+  when: stat_mediawiki_dir
+
 - name: rename mediawiki directory
   command: mv "{{ mediawiki_destination }}/mediawiki-{{ mediawiki_version }}" "{{ mediawiki_destination }}/{{ mediawiki_name }}-{{ mediawiki_version }}"
   when: mediawiki_name != "mediawiki"


### PR DESCRIPTION
---
name: Pull request
about: Use variable instead of hardcoded MediaWiki name

---

**Describe the change**
At the moment, the directory where MediaWiki is unpacked is hardcoded "mediawiki". This should be configurable to allow multiple wikis in the same directory or to follow naming conventions, e.g.:

```
/var/www/html/mediawiki
- wiki01-1.35.1
- wiki01 → wiki01-1.35.1
- test-1.35.1
- test-1.35.2
- test → test-1.35.2
```

**Testing**
see assert.yml, tested locally
